### PR TITLE
dnsChallenge LAN changes

### DIFF
--- a/traefik/README.md
+++ b/traefik/README.md
@@ -11,7 +11,19 @@ Traefik is a modern HTTP reverse proxy and load balancer that makes deploying mi
 ## Known issues and limitations
 
 * Default port 80 can conflict with other ports
-* You cannot use double quotes or escape characters within environment variables
+* Special characters such as spaces must be escaped within environment variables
+
+## DNS Challenge specific options
+* delayBeforeCheck - by default, the provider will verify the TXT DNS challenge
+  record before letting ACME verify. If delayBeforeCheck is greater than zero,
+  this check is delayed for the configured duration in seconds. Useful if
+  internal networks block external DNS queries. For more information, check the
+  [traefik documentation](https://docs.traefik.io/https/acme/#dnschallenge).
+* resolvers - manually set the DNS servers to use when performing the
+  verification step. Useful for situations where internal DNS does not resolve
+  to the same addresses as the public internet (e.g. on a LAN using a FQDN as
+  part of hostnames). For more information, see
+  [here](https://docs.traefik.io/https/acme/#resolvers).
 
 ## Final notes
 

--- a/traefik/build.json
+++ b/traefik/build.json
@@ -1,7 +1,8 @@
 {
     "build_from": {
         "amd64": "hassioaddons/base",
-        "armv7": "hassioaddons/base"
+        "armv7": "hassioaddons/base",
+        "aarch64": "hassioaddons/base"
     },
     "args": {
         "TRAEFIK_VERSION": "2.2.11"

--- a/traefik/config.json
+++ b/traefik/config.json
@@ -3,7 +3,11 @@
     "version": "3.0.3",
     "slug": "traefik",
     "description": "Traefik is a modern HTTP reverse proxy and load balancer that makes deploying microservices easy.",
-    "arch": ["armv7", "amd64"],
+    "arch": [
+        "armv7",
+        "amd64",
+        "aarch64"
+    ],
     "startup": "system",
     "boot": "auto",
     "url": "https://alxx.nl/hassio-addons/tree/master/traefik",

--- a/traefik/config.json
+++ b/traefik/config.json
@@ -2,12 +2,9 @@
     "name": "Traefik",
     "version": "3.0.3",
     "slug": "traefik",
-    "description": "Traefik is a modern HTTP reverse proxy and load balancer that makes deploying microservices easy.",
-    "arch": [
-        "armv7",
-        "amd64",
-        "aarch64"
-    ],
+    "description":
+    "Traefik is a modern HTTP reverse proxy and load balancer that makes deploying microservices easy.",
+    "arch": ["armv7", "amd64", "aarch64"],
     "startup": "system",
     "boot": "auto",
     "url": "https://alxx.nl/hassio-addons/tree/master/traefik",
@@ -22,11 +19,7 @@
     "ingress": true,
     "ingress_entry": "dashboard/",
     "panel_icon": "mdi:earth-arrow-right",
-    "map": [
-        "config",
-        "share",
-        "ssl:rw"
-    ],
+    "map": ["config", "share", "ssl:rw"],
     "options": {
         "log_level": "INFO",
         "access_logs": false,
@@ -50,12 +43,8 @@
             "challenge_type": "match(tlsChallenge|httpChallenge|dnsChallenge)?",
             "provider": "str?",
             "delayBeforeCheck": "int",
-            "resolvers": [
-                "str?"
-            ]
+            "resolvers": ["str?"]
         },
-        "env_vars": [
-            "str"
-        ]
+        "env_vars": ["str"]
     }
 }

--- a/traefik/config.json
+++ b/traefik/config.json
@@ -33,7 +33,9 @@
         "forwarded_headers_insecure": false,
         "dynamic_configuration_path": "/config/traefik/",
         "letsencrypt": {
-            "enabled": false
+            "enabled": false,
+            "delayBeforeCheck": 0,
+            "resolvers": []
         },
         "env_vars": []
     },
@@ -46,8 +48,14 @@
             "enabled": "bool",
             "email": "email?",
             "challenge_type": "match(tlsChallenge|httpChallenge|dnsChallenge)?",
-            "provider": "str?"
+            "provider": "str?",
+            "delayBeforeCheck": "int",
+            "resolvers": [
+                "str?"
+            ]
         },
-        "env_vars": ["str"]
+        "env_vars": [
+            "str"
+        ]
     }
 }

--- a/traefik/run.sh
+++ b/traefik/run.sh
@@ -21,8 +21,8 @@ nginx -g 'pid /tmp/nginx.pid;'
 
 bashio::log.info "Starting Traefik..."
 if [ -z "$ENV_VARS" ]; then
+    bashio::log.info "Running Traefik without env_vars"
     /usr/local/bin/traefik
 else
-    export "${ENV_VARS}"
-    exec /usr/local/bin/traefik
+    env $ENV_VARS /usr/local/bin/traefik
 fi

--- a/traefik/traefik.yaml.j2
+++ b/traefik/traefik.yaml.j2
@@ -38,8 +38,7 @@ certificatesResolvers:
         resolvers:
         {% for resolver in letsencrypt.resolvers -%}
           - "{{ resolver }}"
-
-        {% endfor %}
+        {%- endfor %}
       {%- endif %}
   {%- endif %}
 {%- endif %}

--- a/traefik/traefik.yaml.j2
+++ b/traefik/traefik.yaml.j2
@@ -33,6 +33,14 @@ certificatesResolvers:
   {%- elif letsencrypt.challenge_type == 'dnsChallenge' %}
       dnsChallenge:
         provider: {{ letsencrypt.provider }}
+        delayBeforeCheck: {{ letsencrypt.delayBeforeCheck }}
+      {% if letsencrypt.resolvers %}
+        resolvers:
+        {% for resolver in letsencrypt.resolvers -%}
+          - "{{ resolver }}"
+
+        {% endfor %}
+      {%- endif %}
   {%- endif %}
 {%- endif %}
 


### PR DESCRIPTION
While using this addon to make a dnsChallenge certificate request, I ran into a couple of issues relating to DNS on my LAN not mirroring that of the public internet, as well as special characters in API keys. 

In order to make this work for me, I had to make a couple of changes to allow escape characters in env vars, and add delayBeforeCheck and resolvers to the generated traefik static config.

I also tidied up a little around the previous PR I made, by adding the references to aarch64 in the config and build files.